### PR TITLE
Removed vnfIdEncrypted, cleaned up tests

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,2 @@
 build
+node_modules

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,30 @@
+# bcv-contract
+
+## Project setup
+First, make sure to install the required dependencies:
+```
+npm install
+```
+
+## Contract Management
+Put your contracts into `src/truffle/contracts`. To compile `cd` into
+`src/truffle` and run
+```
+truffle compile
+```
+
+After successful compilation, run migration to deploy the contracts
+```
+truffle migrate --reset
+```
+The `--reset` flag will make sure the contracts are fully migrated even if previous
+versions are already present on the network.
+
+For local development simply open up Ganache with Quickstart. Alternatively, 
+create a workspace in Ganache and import the `truffle-config.js` for more detailed
+info within Ganache.
+
+To test the contract, run the following command:
+```
+truffle test
+```

--- a/src/contracts/VNFDeployment.sol
+++ b/src/contracts/VNFDeployment.sol
@@ -11,9 +11,9 @@ contract VNFDeployment {
 
 	/* --- STRUCTS --- */
 	struct VNF {
-		uint id;
+		uint correlationId;
 		string vnfdId;
-		string encryptedId;
+		string vnfId;
 		address owner;
 		string parameters;
 		bool isDeployed;
@@ -29,7 +29,7 @@ contract VNFDeployment {
 	address public backend;
 
 	// VNF id counter
-	uint private nextVnfId = 1;
+	uint private nextCorrelationId = 1;
 
 	// Contains the registered users
 	mapping (address => bool) private users;
@@ -68,32 +68,34 @@ contract VNFDeployment {
 
 	// Event which signals to the backend to deploy a VNF according to the specified VNFD.
 	/// @param creator address of the user triggering the VNF deployment
-	/// @param vnfId VNF identifier as specified in this contract.
+	/// @param correlationId VNF identifier as specified in this contract.
 	/// @param vnfdId identifier of the VNF descriptor (VNFD), which is
 	/// the template to be used to create a VNF instance (obtained from tacker).
 	/// @param parameters instantiation parameters according to the VNFD.
-	event DeployVNF(address creator, uint vnfId, string vnfdId, string parameters);
+	event DeployVNF(address creator, uint correlationId, string vnfdId, string parameters);
 
 	// Event which signals the deletion of a VNF to the backend.
 	// Must be called by the same user that triggered the VNF deployment.
 	/// @param creator address of the user triggering the VNF deletion.
-	event DeleteVNF(address creator, uint vnfId);
+	/// @param correlationId VNF identifier as specified in this contract.
+	/// @param vnfId VNF identifier as specified by the backend.
+	event DeleteVNF(address creator, uint correlationId, string vnfId);
 
 	// TODO
 	event ModifyVNF(address creator, string vnfId, string parameters);
 
 	// Event which signals the VNF's deployment status to the frontend.
-	/// @param vnfId VNF identifier as specified in this contract.
+	/// @param correlationId VNF identifier as specified in this contract.
 	/// @param user User owning the VNF
 	/// @param success Indicates whether the creation of a VNF was successful.
-	/// @param vnfIdEncrypted Encrypted VNF identifier (can only be decrypted by the user).
-	event DeploymentStatus(uint vnfId, address user, bool success, string vnfIdEncrypted);
+	/// @param vnfId VNF identifier specified by the backend.
+	event DeploymentStatus(uint correlationId, address user, bool success, string vnfId);
 
 	// Event which signals the status of a VNF deletion to the frontend.
-	/// @param vnfId VNF identifier as specified in this contract.
+	/// @param correlationId VNF identifier as specified in this contract.
 	/// @param user User owning the VNF
 	/// @param success Indicates whether the deletion of the VNF was successful.
-	event DeletionStatus(uint vnfId, address user, bool success);
+	event DeletionStatus(uint correlationId, address user, bool success);
 
 	/* --- PUBLIC FUNCTIONS --- */
 
@@ -159,67 +161,67 @@ contract VNFDeployment {
 
 		require(users[user], "User not registered.");
 
-		uint vnfId = createVNFId();
+		uint correlationId = createCorrelationId();
 
-		VNF memory vnf = VNF(vnfId, vnfdId, "", user, parameters, false, false);
+		VNF memory vnf = VNF(correlationId, vnfdId, "", user, parameters, false, false);
 
 		addVnf(vnf, user);
 
-		emit DeployVNF(user, vnfId, vnfdId, parameters);
+		emit DeployVNF(user, correlationId, vnfdId, parameters);
 	}
 
 	// Deletes a VNF by emitting a deletion event.
-	/// @param vnfId identifier of the VNF instance to be terminated.
-	function deleteVNF(uint vnfId) public {
+	/// @param correlationId identifier of the VNF instance to be terminated.
+	function deleteVNF(uint correlationId) public {
 		address user = msg.sender;
 
 		require(users[user], "User not registered.");
 
-		uint index = findVnfIndex(vnfId, user);
+		uint index = findVnfIndex(correlationId, user);
 
 		require(vnfs[user][index].owner == user, "VNF must exist and can only be deleted by its owner");
 
-		emit DeleteVNF(user, vnfId);
+		emit DeleteVNF(user, correlationId, vnfs[user][index].vnfId);
 	}
 
 
 	// Enables the backend to signal the status of VNF deletion.
-	/// @param vnfId VNF identifier as specified in this contract.
+	/// @param correlationId VNF identifier as specified in this contract.
 	/// @param user User owning the VNF
 	/// @param success Indicates whether the VNF was instantiated correctly.
-	function reportDeletion(uint vnfId, address user, bool success) public {
+	function reportDeletion(uint correlationId, address user, bool success) public {
 		require(msg.sender == backend, "Only the backend is allowed to call this function.");
 
 		if(success){
-			removeVnf(vnfId, user);
+			removeVnf(correlationId, user);
 		}
 
-		emit DeletionStatus(vnfId, user, success);
+		emit DeletionStatus(correlationId, user, success);
 	}
 
 	// Enables the backend to signal the status of VNF instantiation
-	// by handing over the VNF resource identifier in an encrypted form.
-	/// @param vnfId VNF identifier as specified in this contract.
+	// by handing over the VNF resource identifier of the backend.
+	/// @param correlationId VNF identifier as specified in this contract.
 	/// @param user User owning the VNF
 	/// @param success Indicates whether the VNF was instantiated correctly.
-	/// @param vnfIdEncrypted Encrypted VNF identifier (can only be decrypted by the user).
-	function reportDeployment(uint vnfId, address user, bool success, string calldata vnfIdEncrypted) external {
+	/// @param vnfId VNF identifier specified by the backend.
+	function reportDeployment(uint correlationId, address user, bool success, string calldata vnfId) external {
 		require(msg.sender == backend, "Only the backend is allowed to call this function.");
 
-		uint index = findVnfIndex(vnfId, user);
+		uint index = findVnfIndex(correlationId, user);
 
-		require(vnfs[user][index].id > 0, "VNF must exist in order to be activated.");
+		require(vnfs[user][index].correlationId > 0, "VNF must exist in order to be activated.");
 
 		if(success){
-			// add vnfIdEncrypted to existing VNF record
-			vnfs[user][index].encryptedId = vnfIdEncrypted;
+			// add vnfId to existing VNF record
+			vnfs[user][index].vnfId = vnfId;
 			vnfs[user][index].isDeployed = true;
 		} else {
 			// remove vnfId from registered VNF list
-			removeVnf(vnfId, user);
+			removeVnf(correlationId, user);
 		}
 
-		emit DeploymentStatus(vnfId, user, success, vnfIdEncrypted);
+		emit DeploymentStatus(correlationId, user, success, vnfId);
 	}
 
 	// DEV
@@ -232,15 +234,14 @@ contract VNFDeployment {
 		return vnfs[user];
 	}
 
-	// DEV
 	/// Returns the details of one specific VNF
-	/// @param vnfId VNF identifier as specified in this contract.
-	function getVnfDetails(uint vnfId) public view returns (VNF memory){
+	/// @param correlationId VNF identifier as specified in this contract.
+	function getVnfDetails(uint correlationId) public view returns (VNF memory){
 		address user = msg.sender;
 
 		require(users[user], "User not registered");
 
-		uint index = findVnfIndex(vnfId, user);
+		uint index = findVnfIndex(correlationId, user);
 
 		VNF memory vnf = vnfs[user][index];
 
@@ -252,19 +253,19 @@ contract VNFDeployment {
 	/* --- PRIVATE FUNCTIONS --- */
 
 	// Creates a new VNF id for keeping track of VNF instantiations
-	function createVNFId() private returns (uint) {
-		return nextVnfId++;
+	function createCorrelationId() private returns (uint) {
+		return nextCorrelationId++;
 	}
 
 	// Returns the VNF index from the vnf array using its ID
 	// Reverts in case nothing is found
-	/// @param vnfId VNF identifier as specified in this contract.
+	/// @param correlationId VNF identifier as specified in this contract.
 	/// @param owner User owning the VNF.
-	function findVnfIndex(uint vnfId, address owner) private view returns (uint){
+	function findVnfIndex(uint correlationId, address owner) private view returns (uint){
 		uint length = vnfs[owner].length;
 
 		for(uint i = 0; i < length; i++){
-			if(vnfs[owner][i].id == vnfId && !vnfs[owner][i].isDeleted){
+			if(vnfs[owner][i].correlationId == correlationId && !vnfs[owner][i].isDeleted){
 				return i;
 			}
 		}
@@ -280,10 +281,10 @@ contract VNFDeployment {
 	}
 
 	// Helper function to manage the vnfs array (delete)
-	/// @param vnfId VNF identifier as specified in this contract.
+	/// @param correlationId VNF identifier as specified in this contract.
 	/// @param owner User owning the VNF.
-	function removeVnf(uint vnfId, address owner) private {
-		uint index = findVnfIndex(vnfId, owner);
+	function removeVnf(uint correlationId, address owner) private {
+		uint index = findVnfIndex(correlationId, owner);
 
 		vnfs[owner][index].isDeleted = true;
 	}

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,0 +1,55 @@
+{
+  "name": "src",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "truffle-assertions": "^0.9.2"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "node_modules/truffle-assertions": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/truffle-assertions/-/truffle-assertions-0.9.2.tgz",
+      "integrity": "sha512-9g2RhaxU2F8DeWhqoGQvL/bV8QVoSnQ6PY+ZPvYRP5eF7+/8LExb4mjLx/FeliLTjc3Tv1SABG05Gu5qQ/ErmA==",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "lodash.isequal": "^4.5.0"
+      }
+    }
+  },
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "truffle-assertions": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/truffle-assertions/-/truffle-assertions-0.9.2.tgz",
+      "integrity": "sha512-9g2RhaxU2F8DeWhqoGQvL/bV8QVoSnQ6PY+ZPvYRP5eF7+/8LExb4mjLx/FeliLTjc3Tv1SABG05Gu5qQ/ErmA==",
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "lodash.isequal": "^4.5.0"
+      }
+    }
+  }
+}

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "truffle-assertions": "^0.9.2"
+  }
+}

--- a/src/test/VNFDeployment.js
+++ b/src/test/VNFDeployment.js
@@ -90,7 +90,7 @@ contract("VNFDeployment", accounts => {
     // assert
     assert.equal(result.event, "DeployVNF");
     assert.equal(result.args["creator"], user);
-    assert.equal(result.args["vnfId"], 1);
+    assert.equal(result.args["correlationId"], 1);
     assert.equal(result.args["vnfdId"], vnfdId);
     assert.equal(result.args["parameters"], params);
   });
@@ -104,30 +104,32 @@ contract("VNFDeployment", accounts => {
     const vnfdId = "1";
     const params = "ram=1G,cpu=2,disk=500G";
     await instance.deployVNF(vnfdId, params);
-    const vnfId = 1;
-    const vnfIdEncrypted = "0xfabababababababab";
+    const correlationId = 1;
+    const vnfId = "0xfabababababababab";
 
     // act
-    const result = (await instance.reportDeployment(vnfId, user, true, vnfIdEncrypted)).logs[0];
+    const result = (await instance.reportDeployment(correlationId, user, true, vnfId)).logs[0];
 
     // assert
     assert.equal(result.event, "DeploymentStatus");
-    assert.equal(result.args["vnfId"], vnfId);
+    assert.equal(result.args["correlationId"], correlationId);
     assert.equal(result.args["user"], user);
     assert.equal(result.args["success"], true);
-    assert.equal(result.args["vnfIdEncrypted"], vnfIdEncrypted);
+    assert.equal(result.args["vnfId"], vnfId);
   });
 
   it("should emit a DeleteVNF event", async() => {
     // arrange
     const instance = await VNFDeployment.deployed();
     const user = await instance.creator();
+    const vnfId = "ASDF-8291-DFEA";
     await instance.registerBackend(user);
     await instance.reportRegistration(user, true);
 
     const vnfdId = "1";
     const params = "ram=1G,cpu=2,disk=500G";
-    await instance.deployVNF(vnfdId, params)
+    await instance.deployVNF(vnfdId, params);
+    await instance.reportDeployment(1, user, true, vnfId);
 
     // act
     const result = (await instance.deleteVNF(1)).logs[0];
@@ -135,7 +137,8 @@ contract("VNFDeployment", accounts => {
     // assert
     assert.equal(result.event, "DeleteVNF");
     assert.equal(result.args["creator"], user);
-    assert.equal(result.args["vnfId"], 1);
+    assert.equal(result.args["correlationId"], 1);
+    assert.equal(result.args["vnfId"], vnfId);
   });
 
   it("should emit a DeletionStatus event", async() => {
@@ -147,15 +150,15 @@ contract("VNFDeployment", accounts => {
     const vnfdId = "1";
     const params = "ram=1G,cpu=2,disk=500G";
     await instance.deployVNF(vnfdId, params);
-    const vnfId = 1;
+    const correlationId = 1;
     const vnfIdEncrypted = "0xfabababababababab";
 
     // act
-    const result = (await instance.reportDeletion(vnfId, user, true)).logs[0];
+    const result = (await instance.reportDeletion(correlationId, user, true)).logs[0];
 
     // assert
     assert.equal(result.event, "DeletionStatus");
-    assert.equal(result.args["vnfId"], vnfId);
+    assert.equal(result.args["correlationId"], correlationId);
     assert.equal(result.args["user"], user);
     assert.equal(result.args["success"], true);
   });

--- a/src/test/VNFDeployment.js
+++ b/src/test/VNFDeployment.js
@@ -9,180 +9,186 @@ contract("VNFDeployment", accounts => {
     instance = await VNFDeployment.new();
   });
 
-  it("should set the creator of the contract", async() =>{
-    // act, assert
-    assert.notEqual(await instance.creator(), null);
-  });
+  describe('--- CONTRACT SET UP TESTS ---', () => {
+    it("should set the creator of the contract", async() =>{
+      // act, assert
+      assert.notEqual(await instance.creator(), null);
+    });
 
-  it("should set the backend", async() =>{
-    // arrange
-    const user = accounts[1];
+    it("should set the backend", async() =>{
+      // arrange
+      const user = accounts[1];
 
-    // act
-    await instance.registerBackend(user);
+      // act
+      await instance.registerBackend(user);
 
-    // assert
-    assert.equal(await instance.backend(), user);
-  });
-
-  it("should deny deployVNF for unregistered users", async() => {
-    // act, assert
-    await truffleAssert.reverts(instance.deployVNF("12", "asdf=test"), "User not registered.");
-  });
-
-  it("should deny deleteVNF for unregistered users", async() => {
-    // act, assert
-    await truffleAssert.reverts(instance.deleteVNF(1), "User not registered.");
-  });
-
-  it("should deny reportDeployment for unregistered backend", async() => {
-    // arrange
-    const user = accounts[1];
-
-    // act, assert
-    await truffleAssert.reverts(instance.reportDeployment(1, user, true, "someId"), "Only the backend is allowed to call this function.");
-  });
-
-  it("should deny reportDeletion for unregistered backend", async() => {
-    // arrange
-    const user = accounts[1];
-
-    // act, assert
-    await truffleAssert.reverts(instance.reportDeletion(1, user, true), "Only the backend is allowed to call this function.");
-  });
-
-  it("should deny reportRegistration for unregistered backend", async() => {
-    // arrange
-    const user = accounts[1];
-
-    // act, assert
-    await truffleAssert.reverts(instance.reportRegistration(user, true), "Only the backend is allowed to call this function.");
-  });
-
-  it("should emit a Register event", async() =>{
-    // act
-    const result = await instance.registerUser("xyz");
-
-    // assert
-    truffleAssert.eventEmitted(result, "Register", async(e) => {
-      return e.user == await instance.creator() && e.signedAddress == "xyz";
+      // assert
+      assert.equal(await instance.backend(), user);
     });
   });
 
-  it("should emit a RegistrationStatus event", async() =>{
-    // arrange
-    await instance.registerBackend(await instance.creator());
+  describe('--- UNREGISTERED USER HANDLING TESTS ---', () => {
+    it("should deny deployVNF for unregistered users", async() => {
+      // act, assert
+      await truffleAssert.reverts(instance.deployVNF("12", "asdf=test"), "User not registered.");
+    });
 
-    // act
-    const result = await instance.reportRegistration(accounts[1], true);
+    it("should deny deleteVNF for unregistered users", async() => {
+      // act, assert
+      await truffleAssert.reverts(instance.deleteVNF(1), "User not registered.");
+    });
 
-    // assert
-    truffleAssert.eventEmitted(result, "RegistrationStatus", e => {
-      return e.user == accounts[1] && e.success == true;
+    it("should deny reportDeployment for unregistered backend", async() => {
+      // arrange
+      const user = accounts[1];
+
+      // act, assert
+      await truffleAssert.reverts(instance.reportDeployment(1, user, true, "someId"), "Only the backend is allowed to call this function.");
+    });
+
+    it("should deny reportDeletion for unregistered backend", async() => {
+      // arrange
+      const user = accounts[1];
+
+      // act, assert
+      await truffleAssert.reverts(instance.reportDeletion(1, user, true), "Only the backend is allowed to call this function.");
+    });
+
+    it("should deny reportRegistration for unregistered backend", async() => {
+      // arrange
+      const user = accounts[1];
+
+      // act, assert
+      await truffleAssert.reverts(instance.reportRegistration(user, true), "Only the backend is allowed to call this function.");
     });
   });
 
-  it("should emit a Unregister event", async() => {
-    // act
-    const result = await instance.unregisterUser();
+  describe('--- EVENT EMISSION TESTS ---', () => {
+    it("should emit a Register event", async() =>{
+      // act
+      const result = await instance.registerUser("xyz");
 
-    // assert
-    truffleAssert.eventEmitted(result, "Unregister", async(e) => {
-      return e.user == await instance.creator();
+      // assert
+      truffleAssert.eventEmitted(result, "Register", async(e) => {
+        return e.user == await instance.creator() && e.signedAddress == "xyz";
+      });
     });
-  });
 
-  it("should emit a UnegistrationStatus event", async() =>{
-    // arrange
-    await instance.registerBackend(await instance.creator());
+    it("should emit a RegistrationStatus event", async() =>{
+      // arrange
+      await instance.registerBackend(await instance.creator());
 
-    // act
-    const result = await instance.reportUnregistration(accounts[1], true);
+      // act
+      const result = await instance.reportRegistration(accounts[1], true);
 
-    // assert
-    truffleAssert.eventEmitted(result, "UnregistrationStatus", e => {
-      return e.user == accounts[1] && e.success == true;
+      // assert
+      truffleAssert.eventEmitted(result, "RegistrationStatus", e => {
+        return e.user == accounts[1] && e.success == true;
+      });
     });
-  });
 
-  it("should emit a DeployVNF event", async() => {
-    // arrange
-    const user = await instance.creator();
-    await instance.registerBackend(user);
-    await instance.reportRegistration(user, true);
+    it("should emit a Unregister event", async() => {
+      // act
+      const result = await instance.unregisterUser();
 
-    const vnfdId = "XYZ";
-    const params = "ram=1G,cpu=2,disk=500G";
-
-    // act
-    const result = await instance.deployVNF(vnfdId, params);
-
-    // assert
-    truffleAssert.eventEmitted(result, "DeployVNF", e => {
-      return e.creator === user && e.correlationId == 1 && e.vnfdId == vnfdId && e.parameters == params;
+      // assert
+      truffleAssert.eventEmitted(result, "Unregister", async(e) => {
+        return e.user == await instance.creator();
+      });
     });
-  });
 
-  it("should emit a DeploymentStatus event", async() => {
-    // arrange
-    const user = await instance.creator();
-    await instance.registerBackend(user);
-    await instance.reportRegistration(user, true);
-    const vnfdId = "XYZ";
-    const params = "ram=1G,cpu=2,disk=500G";
-    await instance.deployVNF(vnfdId, params);
-    const correlationId = 1;
-    const vnfId = "0xfabababababababab";
+    it("should emit a UnegistrationStatus event", async() =>{
+      // arrange
+      await instance.registerBackend(await instance.creator());
 
-    // act
-    const result = await instance.reportDeployment(correlationId, user, true, vnfId);
+      // act
+      const result = await instance.reportUnregistration(accounts[1], true);
 
-    // assert
-    truffleAssert.eventEmitted(result, "DeploymentStatus", e => {
-      return e.correlationId == correlationId && e.user == user && e.success == true && e.vnfId == vnfId;
+      // assert
+      truffleAssert.eventEmitted(result, "UnregistrationStatus", e => {
+        return e.user == accounts[1] && e.success == true;
+      });
     });
-  });
 
-  it("should emit a DeleteVNF event", async() => {
-    // arrange
-    // const instance = await sc.deployed();
-    const user = await instance.creator();
-    const vnfId = "ASDF-8291-DFEA";
-    await instance.registerBackend(user);
-    await instance.reportRegistration(user, true);
+    it("should emit a DeployVNF event", async() => {
+      // arrange
+      const user = await instance.creator();
+      await instance.registerBackend(user);
+      await instance.reportRegistration(user, true);
 
-    const vnfdId = "XYZ";
-    const params = "ram=1G,cpu=2,disk=500G";
-    await instance.deployVNF(vnfdId, params);
-    await instance.reportDeployment(1, user, true, vnfId);
+      const vnfdId = "XYZ";
+      const params = "ram=1G,cpu=2,disk=500G";
 
-    // act
-    const result = await instance.deleteVNF(1);
+      // act
+      const result = await instance.deployVNF(vnfdId, params);
 
-    // assert
-    truffleAssert.eventEmitted(result, "DeleteVNF", e => {
-      return e.creator == user && e.correlationId == 1 && e.vnfId == vnfId;
+      // assert
+      truffleAssert.eventEmitted(result, "DeployVNF", e => {
+        return e.creator === user && e.deploymentId == 1 && e.vnfdId == vnfdId && e.parameters == params;
+      });
     });
-  });
 
-  it("should emit a DeletionStatus event", async() => {
-    // arrange
-    // const instance = await sc.deployed();
-    const user = await instance.creator();
-    await instance.registerBackend(user);
-    await instance.reportRegistration(user, true);
-    const vnfdId = "XYZ";
-    const params = "ram=1G,cpu=2,disk=500G";
-    await instance.deployVNF(vnfdId, params);
-    const correlationId = 1;
-    const vnfIdEncrypted = "0xfabababababababab";
+    it("should emit a DeploymentStatus event", async() => {
+      // arrange
+      const user = await instance.creator();
+      await instance.registerBackend(user);
+      await instance.reportRegistration(user, true);
+      const vnfdId = "XYZ";
+      const params = "ram=1G,cpu=2,disk=500G";
+      await instance.deployVNF(vnfdId, params);
+      const deploymentId = 1;
+      const vnfId = "0xfabababababababab";
 
-    // act
-    const result = await instance.reportDeletion(correlationId, user, true);
+      // act
+      const result = await instance.reportDeployment(deploymentId, user, true, vnfId);
 
-    // assert
-    truffleAssert.eventEmitted(result, "DeletionStatus", e => {
-      return e.correlationId == correlationId && e.user == user && e.success == true;
+      // assert
+      truffleAssert.eventEmitted(result, "DeploymentStatus", e => {
+        return e.deploymentId == deploymentId && e.user == user && e.success == true && e.vnfId == vnfId;
+      });
+    });
+
+    it("should emit a DeleteVNF event", async() => {
+      // arrange
+      // const instance = await sc.deployed();
+      const user = await instance.creator();
+      const vnfId = "ASDF-8291-DFEA";
+      await instance.registerBackend(user);
+      await instance.reportRegistration(user, true);
+
+      const vnfdId = "XYZ";
+      const params = "ram=1G,cpu=2,disk=500G";
+      await instance.deployVNF(vnfdId, params);
+      await instance.reportDeployment(1, user, true, vnfId);
+
+      // act
+      const result = await instance.deleteVNF(1);
+
+      // assert
+      truffleAssert.eventEmitted(result, "DeleteVNF", e => {
+        return e.creator == user && e.deploymentId == 1 && e.vnfId == vnfId;
+      });
+    });
+
+    it("should emit a DeletionStatus event", async() => {
+      // arrange
+      // const instance = await sc.deployed();
+      const user = await instance.creator();
+      await instance.registerBackend(user);
+      await instance.reportRegistration(user, true);
+      const vnfdId = "XYZ";
+      const params = "ram=1G,cpu=2,disk=500G";
+      await instance.deployVNF(vnfdId, params);
+      const deploymentId = 1;
+      const vnfIdEncrypted = "0xfabababababababab";
+
+      // act
+      const result = await instance.reportDeletion(deploymentId, user, true);
+
+      // assert
+      truffleAssert.eventEmitted(result, "DeletionStatus", e => {
+        return e.deploymentId == deploymentId && e.user == user && e.success == true;
+      });
     });
   });
 


### PR DESCRIPTION
- Removed vnfIdEncrypted
- Renamed vnfId to correlationId to reduce confusion
- Field vnfId is used for tacker generated ID
- Unit tests have been cleaned up and some new cases have been defined.